### PR TITLE
Feature #14 Implementing Rails Internationalization (I18n)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'rails-i18n'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -209,6 +212,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)
+  rails-i18n
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,31 +2,44 @@
   <div class="container">
     <nav class="pt-5">
       <div class="navegation mb-5">
-        <h1 class="text-white">BrightCoders</h1>
+        <h1 class="text-white"><%= t('title.brightcoders') %></h1>
       </div>
     </nav>
     <section class="hero">
       <div class="hero-info">
-        <h1 class="hero-info_heading"> Desarrolla e <br></h1>
-        <span class="hero-info_heading-span">impulsta tu talento.</span>
+        <h1 class="hero-info_heading"><%= t('hero.heading') %></h1>
+        <span class="hero-info_heading-span"><%= t('hero.heading_span') %></span>
         <div class="hero-info_text-v1">
-          <p class="hero-info_text-v1_p">mediante una experiencia</p>
-          <p class="hero-info_text-v1_p">de aprendizaje única.</p>
+          <p class="hero-info_text-v1_p"><%= t('hero.info_p1_r1') %></p>
+          <p class="hero-info_text-v1_p"><%= t('hero.info_p1_r2') %></p>
         </div>
         <div class="hero-info_text-v2">
-          <p class="hero-info_text-v2_p">Vive una experiencia de </p>
-          <p class="hero-info_text-v2_p">aprendizaje única.</p>
+          <p class="hero-info_text-v2_p"><%= t('hero.info_p2_r1') %></p>
+          <p class="hero-info_text-v2_p"><%= t('hero.info_p2_r2') %></p>
         </div>
-        <a href="#" class="hero-info_button">Conoce nuestros programas</a>
+        <a href="#" class="hero-info_button"><%= t('hero.button') %></a>
       </div>
 
       <div class="hero-image">
-        <%= image_tag("Image 2.webp", alt:"Woman image", class:"hero-image_women")%>
+        <%= image_tag("Image 2.webp", alt: t('hero.image'), class:"hero-image_women")%>
         <div class="hero-image_rectangles">
-          <%=image_tag("Group 608.png", alt: "Colored rectangles", class:"hero-image_rectangles-colored1")%>
-          <%=image_tag("Group 608.png", alt: "Colored rectangles", class:"hero-image_rectangles-colored2")%>
+          <%=image_tag("Group 608.png", alt: t('hero.image_background'), class:"hero-image_rectangles-colored1")%>
+          <%=image_tag("Group 608.png", alt: t('hero.image_background'), class:"hero-image_rectangles-colored2")%>
         </div>
       </div>
     </section>
   </div>
 </section>
+
+<% t('description_section.items').each do |item| %>
+  <div class="col-lg-4 col-md-6 p-2 mx-auto">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="title"><%= item[:title] %></h5>
+        <p class="card-text">
+          <%= item[:description] %>
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,28 +1,28 @@
 <nav class="navbar navbar-expand-lg navbar-light ">
   <div class="container-fluid">
     <div class="logo-container-close" id = "logo-container">
-      <%= image_tag "BCnameLogo.png", alt: "BCLogo", class: "logo-closed", id:"logo" %> 
+      <%= image_tag "BCnameLogo.png", alt: t('menu.logo'), class: "logo-closed", id:"logo" %>
     </div>
     <button id="button" class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02"
       aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation" style="border: none; box-shadow: none">
-      <%= image_tag "list.svg", alt: "BCLogo", id:"image" %> 
+      <%= image_tag "list.svg", alt: t('menu.logo'), id:"image" %>
     </button>
     <div class="collapse navbar-collapse " id="navbarTogglerDemo02">
       <div class="navbar-nav ms-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="#" id="link">Nosotros</a>
+          <a class="nav-link" aria-current="page" href="#" id="link"><%= t('menu.about_us') %></a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="#" id="link">Programas</a>
+          <a class="nav-link" aria-current="page" href="#" id="link"><%= t('menu.study_programs') %></a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="#" id="link">Graduados</a>
+          <a class="nav-link" aria-current="page" href="#" id="link"><%= t('menu.graduates') %></a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" aria-current="page" href="#" id="link">Convocatorias</a>
+          <a class="nav-link" aria-current="page" href="#" id="link"><%= t('menu.announcement') %></a>
         </li>
         <li class="nav-item" id="borderContacto">
-          <a class="nav-link" aria-current="page" href="#" id="linkContacto">Contacto</a>
+          <a class="nav-link" aria-current="page" href="#" id="linkContacto"><%= t('menu.contact') %></a>
         </li>
         
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,12 @@ module BcLandingPage2021
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.i18n.available_locales = %i[es en]
+
+    config.i18n.default_locale = 'es'
+
+    config.time_zone = 'Mexico City'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,37 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  menu:
+    logo: "BrightCoders Academy Logo"
+    about_us: "About us"
+    study_programs: "Programs"
+    graduates: "Graduates"
+    announcement: "Announcement"
+    contact: "Contact"
+  title:
+    brightcoders: "BrightCoders"
+  hero:
+    heading: "Develop and"
+    heading_span: "boost your talent."
+    info_p1_r1: "Through a unique"
+    info_p1_r2: "learning experience."
+    info_p2_r1: "Live a unique"
+    info_p2_r2: "learning experience."
+    button: "Get to know our programs"
+    image: "Developer woman"
+    image_background: "Colored shapes"
+  description_section:
+    items:
+    - title: "What are we?"
+      description: "We are a talent accelerator that provides young people with initiative and desire to learn programs
+                certification designed to enhance your skills, improve your chances of accessing a job from
+                quality and living conditions."
+      icon: 'icon-cap'
+    - title: "What do we offer?"
+      description: "A unique learning experience that will allow you to start a career in technology thanks to the
+                training and experience that you will achieve by collaborating on real software development projects and
+                accompaniment by a community of experienced mentors."
+      icon: 'icon-computer'
+    - title: "BrightCoders"
+      description: "BrightCoders Academy trains students, graduates and young people with a desire to learn and with knowledge
+                Intermediate object-oriented programming in HTML, CCS, and JS to start a career in technology.
+                It is also an option to accredit internships or professional stays."
+      icon: 'icon-lamp'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,37 @@
+es:
+  menu:
+    logo: "BrightCoders Academy Logo"
+    about_us: "Nosotros"
+    study_programs: "Programas"
+    graduates: "Graduados"
+    announcement: "Convocatorias"
+    contact: "Contacto"
+  title:
+    brightcoders: "BrightCoders"
+  hero:
+    heading: "Desarrolla e"
+    heading_span: "impulsa tu talento."
+    info_p1_r1: "Mediante una experiencia"
+    info_p1_r2: "de aprendizaje única."
+    info_p2_r1: "Vive una experiencia de"
+    info_p2_r2: "aprendizaje única."
+    button: "Conoce nuestros programas"
+    image: "Mujer desarrolladora"
+    image_background: "Formas de colores"
+  description_section:
+    items:
+    - title: "¿Qué somos?"
+      description: "Somos una aceleradora de talento que brinda a jóvenes con iniciativa y ganas de aprender programas de
+                certificación diseñados para potenciar sus habilidades, mejorar sus posibilidades de acceso a un empleo de
+                calidad y condiciones de vida."
+      icon: 'icon-cap'
+    - title: "¿Qué ofrecemos?"
+      description: "Una experiencia de aprendizaje única que te permitirá iniciar una carrera en tecnología gracias a la
+                capacitación y experiencia que lograrás colaborando en proyectos de desarrollo software reales y el
+                acompañamiento de una comunidad de mentores experimentados."
+      icon: 'icon-computer'
+    - title: "BrightCoders"
+      description: "BrightCoders Academy capacita a estudiantes, egresados y jóvenes con ganas de aprender y con conocimientos
+                intermedios de programación orientada a objetos en HTML, CCS, y JS para iniciar una carrera en tecnología.
+                También es una opción para acreditar las prácticas o estancias profesionales."
+      icon: 'icon-lamp'


### PR DESCRIPTION
# Description
With this Pull Request it is expected to solve the need raised in [issue #14](https://github.com/bright-coders/bc-landing-page-2021/issues/14).

The Ruby I18n (shorthand for internationalization) gem which is shipped with Ruby on Rails provides an easy-to-use and extensible framework for translating our application to a single custom language other than English or for providing multi-language support in your application.

The process of "internationalization" usually means to abstract all strings and other locale specific bits (such as date or currency formats) out of our application.
 
# Running
## Install the required gems

Run the command:

`bundle `

or 

`bundle install`
 
## Install JavaScript packages

Run the command:

`yarn`

## Set up database

Copy the file `/config/database.yml.example` and rename it to `/config/database.yml`, in this file place your PostgreSQL configuration. Later, run the command:

`rails db:setup`

This command will create the database, load the schema, and initialize it with the seed data.

If there are pending migrations, also run the command:

`rails db:migrate`

## Run the Rails server

Run the command:

`rails s`

or

`rails server`

When the server is running, try to access [http://localhost:3000](http://localhost:3000)
  
## Screenshots 
  
### Spanish
![imagen](https://user-images.githubusercontent.com/12243331/132612802-187c0da5-b1a6-4b55-8356-b9d74bc99d20.png)

### English
![imagen](https://user-images.githubusercontent.com/12243331/132612939-23db6b25-dd0d-4d58-b1a4-9ff7c8c2cb24.png)
